### PR TITLE
Added search type property to ionicFilterBar scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ A service you can inject in your controller to show the filter bar
     should be considered a match.  This is the same as the angular filter `comparator` argument described [here](https://docs.angularjs.org/api/ng/filter/filter).  
     Default value is `undefined`.
     
+  - `{string=}` `searchType`
+
+    A string which sets the HTML5 search input type. Examples include search, text, email, tel, number, date, month, password. Full list available [here](http://ionicframework.com/html5-input-types/).
+    Default value is `search`.
+    
   - `[String]` `filterProperties`
 
     A string or string array of object properties that will be used to create a filterExpression object for

--- a/dist/ionic.filter.bar.js
+++ b/dist/ionic.filter.bar.js
@@ -17,7 +17,7 @@ angular.module('jett.ionic.filter.bar', ['ionic']);
               '<div class="bar bar-header bar-{{::config.theme}} item-input-inset">' +
                 '<button class="filter-bar-cancel button button-icon icon {{::config.back}}"></button>' +
                 '<label class="item-input-wrapper">' +
-                  '<input type="search" class="filter-bar-search" ng-model="data.filterText" placeholder="{{::config.placeholder}}" />' +
+                  '<input type="{{::searchType}}" class="filter-bar-search" ng-model="data.filterText" placeholder="{{::config.placeholder}}" />' +
                   '<button class="filter-bar-clear button button-icon icon" ng-class="getClearButtonClass()"></button>' +
                 '</label>' +
               '</div>' +
@@ -28,7 +28,7 @@ angular.module('jett.ionic.filter.bar', ['ionic']);
               '<div class="bar bar-header bar-{{::config.theme}} item-input-inset">' +
                 '<label class="item-input-wrapper">' +
                   '<i class="icon {{::config.search}} placeholder-icon"></i>' +
-                  '<input type="search" class="filter-bar-search" ng-model="data.filterText" placeholder="{{::config.placeholder}}"/>' +
+                  '<input type="{{::searchType}}" class="filter-bar-search" ng-model="data.filterText" placeholder="{{::config.placeholder}}"/>' +
                   '<button class="filter-bar-clear button button-icon icon" ng-class="getClearButtonClass()"></button>' +
                 '</label>' +
                 '<button class="filter-bar-cancel button button-clear" ng-bind-html="::cancelText"></button>' +
@@ -438,7 +438,8 @@ angular.module('jett.ionic.filter.bar', ['ionic']);
             favoritesTitle: 'Favorite Searches',
             favoritesAddPlaceholder: 'Add a search term',
             favoritesEnabled: false,
-            favoritesKey: 'ionic_filter_bar_favorites'
+            favoritesKey: 'ionic_filter_bar_favorites',
+            searchType: 'search'
           }, opts);
 
           scope.data = {filterText: ''};

--- a/dist/ionic.filter.bar.js
+++ b/dist/ionic.filter.bar.js
@@ -536,7 +536,7 @@ angular.module('jett.ionic.filter.bar', ['ionic']);
 
             // pass back original list if filterText is empty.
             // Otherwise filter by expression, supplied properties, or filterText.
-            if (!filterText.length) {
+            if (!(filterText.toString().length)) {
               filteredItems = scope.items;
             } else {
               if (scope.expression) {


### PR DESCRIPTION
I required a date and month picker in the search so extended the plugin. The factory IonicFilterBar has added the following _searchType_ property which allows the HTML input element to have the type set. This can be configured from an angular controller as an option on the show() function. E.g:

```
 filterBarInstance = $ionicFilterBar.show({searchtype:'text'}});
```

I've run the karma unit tests which pass 11/11 and tested it on android/ios with several search inputs of different types inside one view, all seems ok. The component change is not supported on the favourites bar, let me know if you would like this too.
