### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="demo/resources/icon.png" align="left" height="85" width="85">
 
-#Ionic Filter Bar
+# Ionic Filter Bar
 >A platform specific search filter plugin for the Ionic Framework (iOS / Android)
 
 ## Table of Contents


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
